### PR TITLE
prevent macos on arm machines from pulling an arm Debian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 #
 
 # Use a lightweight debian base image
-FROM debian:stable-slim
+FROM --platform=linux/amd64 debian:stable-slim
 
 # Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Apparently the Arm Debian container has some tools missing; this makes the Dockerfile build things with macOS M* machines.
