### PR TITLE
(Naive) fix for DTA incompatibility

### DIFF
--- a/acsi2stm/Acsi.cpp
+++ b/acsi2stm/Acsi.cpp
@@ -38,7 +38,7 @@ void Acsi::onReset() {
 }
 
 void Acsi::refresh() {
-  uint32_t realId = blockDev.mediaId();
+  uint16_t realId = blockDev.mediaId();
   if(realId == mediaId)
     return;
 

--- a/acsi2stm/Acsi.h
+++ b/acsi2stm/Acsi.h
@@ -91,7 +91,7 @@ public:
   SdDev &blockDev;
 
   // Last media ID
-  uint32_t mediaId = 0;
+  uint16_t mediaId = 0;
 
   // SCSI status variables
   ScsiErr lastErr;

--- a/acsi2stm/BlockDev.cpp
+++ b/acsi2stm/BlockDev.cpp
@@ -164,11 +164,11 @@ bool ImageDev::isWritable() {
   return image.isWritable();
 }
 
-uint32_t ImageDev::mediaId(BlockDev::MediaIdMode mode) {
+uint16_t ImageDev::mediaId(BlockDev::MediaIdMode mode) {
   // For now, images cannot be switched on the fly so they cannot change
   // unless the SD card is physically swapped. Derive mediaId from the SD
   // card itself
-  uint32_t id = sd.mediaId(mode);
+  uint16_t id = sd.mediaId(mode);
   if(!id || id != sdMediaId) {
     // No medium or SD card swapped: abort ASAP
     close();
@@ -236,7 +236,7 @@ beginOk:
     writable = !digitalRead(wpPin);
 #endif
 
-    uint32_t id = mediaId(FORCE);
+    uint16_t id = mediaId(FORCE);
 
     // Open the file system
     image.close();
@@ -437,7 +437,7 @@ bool SdDev::isWritable() {
   return writable;
 }
 
-uint32_t SdDev::mediaId(BlockDev::MediaIdMode mediaIdMode) {
+uint16_t SdDev::mediaId(BlockDev::MediaIdMode mediaIdMode) {
   if(mode == DISABLED)
     return 0;
 
@@ -490,9 +490,9 @@ uint32_t SdDev::mediaId(BlockDev::MediaIdMode mediaIdMode) {
     // init() called us again, just return the updated value
     return lastMediaId;
 
-  uint32_t id = 0;
-  for(unsigned int i = 0; i < sizeof(cid) / 4; ++i)
-    id ^= ((const uint32_t*)&cid)[i];
+  uint16_t id = 0;
+  for(unsigned int i = 0; i < sizeof(cid) / 2; ++i)
+    id ^= ((const uint16_t*)&cid)[i];
 
   // Make sure the same card transfered to another slot won't give the same value
   id += slot * 2;

--- a/acsi2stm/BlockDev.h
+++ b/acsi2stm/BlockDev.h
@@ -45,7 +45,7 @@ public:
   // Return a (hopefully) unique id for this media
   // Returns 0 if no device is present
   // Also serves as a device state detection and refresh
-  virtual uint32_t mediaId(MediaIdMode mode = NORMAL) = 0;
+  virtual uint16_t mediaId(MediaIdMode mode = NORMAL) = 0;
 
   // Size in 512 bytes blocks
   uint32_t blocks;
@@ -76,13 +76,13 @@ public:
   virtual bool writeData(const uint8_t *data, int count = 1);
   virtual bool writeStop();
   virtual bool isWritable();
-  virtual uint32_t mediaId(MediaIdMode mode = NORMAL);
+  virtual uint16_t mediaId(MediaIdMode mode = NORMAL);
 
   SdDev &sd;
   FsBaseFile image;
 
 protected:
-  uint32_t sdMediaId; // SD card owning the current image
+  uint16_t sdMediaId; // SD card owning the current image
 };
 
 // Actual SD card slot
@@ -122,7 +122,7 @@ public:
   virtual bool writeData(const uint8_t *data, int count = 1);
   virtual bool writeStop();
   virtual bool isWritable();
-  virtual uint32_t mediaId(MediaIdMode = NORMAL);
+  virtual uint16_t mediaId(MediaIdMode = NORMAL);
 
   // Permanently disable the slot
   void disable();
@@ -149,7 +149,7 @@ public:
   friend class ImageDev;
 protected:
   static const uint32_t mediaCheckPeriod = 500;
-  uint32_t lastMediaId;
+  uint16_t lastMediaId;
   uint32_t lastMediaCheckTime;
   void reset();
 };

--- a/acsi2stm/GemDrive.cpp
+++ b/acsi2stm/GemDrive.cpp
@@ -2127,7 +2127,7 @@ GemDrive * GemDrive::getDrive(uint8_t id) {
   return nullptr;
 }
 
-GemDrive * GemDrive::getDrive(uint32_t mediaId, BlockDev::MediaIdMode mode) {
+GemDrive * GemDrive::getDrive(uint16_t mediaId, BlockDev::MediaIdMode mode) {
   if(!mediaId)
     return nullptr;
 

--- a/acsi2stm/GemDrive.h
+++ b/acsi2stm/GemDrive.h
@@ -93,13 +93,14 @@ struct TOS_PACKED GemPattern {
 // GemDrive DTA, compatible with TOS DTA
 struct TOS_PACKED GemDriveDTA {
   TinyFile file;
+  uint8_t attribMask;
+  uint8_t unused;
   GemPattern pattern;
   uint8_t d_attrib;
   Word d_time;
   Word d_date;
   Long d_length;
-  char d_fname[13];
-  uint8_t attribMask;
+  char d_fname[14];
 };
 
 struct GemPath: public FsFile {
@@ -141,7 +142,7 @@ protected:
   uint16_t indexes[maxDepth];
   SdDev &sd;
 public:
-  uint32_t mediaId;
+  uint16_t mediaId;
 };
 
 struct GemFile: public TinyFile {
@@ -211,7 +212,7 @@ struct GemDrive: public Devices, public Tos {
   static GemDrive * getDrive(char *path, char **outPath = nullptr);
   static GemDrive * getDrive(Long pathAddr, char **outPath = nullptr);
   static GemDrive * getDrive(uint8_t driveId);
-  static GemDrive * getDrive(uint32_t mediaId, BlockDev::MediaIdMode mode = BlockDev::NORMAL);
+  static GemDrive * getDrive(uint16_t mediaId, BlockDev::MediaIdMode mode = BlockDev::NORMAL);
   static void closeProcessFiles();
   static oflag_t attribToSdFat(uint8_t attrib);
   static bool ownFd(Word fd);

--- a/acsi2stm/TinyFile.cpp
+++ b/acsi2stm/TinyFile.cpp
@@ -24,15 +24,16 @@
 #include "TinyFile.h"
 
 TinyFile::TinyFile() : index(0) {
+
 }
 
-void TinyFile::set(uint32_t mediaId_, FsFile &parent, FsFile &file) {
+void TinyFile::set(uint16_t mediaId_, FsFile &parent, FsFile &file) {
   mediaId = mediaId_;
   dirCluster = getCluster(parent);
   index = file.dirIndex() + 1;
 };
 
-void TinyFile::set(uint32_t mediaId_, FsFile &parent) {
+void TinyFile::set(uint16_t mediaId_, FsFile &parent) {
   mediaId = mediaId_;
   dirCluster = getCluster(parent);
   index = 0;
@@ -150,7 +151,7 @@ void TinyFile::closeLast() {
   lastMediaId = 0;
 }
 
-void TinyFile::ejected(uint32_t mediaId) {
+void TinyFile::ejected(uint16_t mediaId) {
   // Called on SD card hot swap
   if(mediaId == lastMediaId) {
     lastFile = FsFile();
@@ -161,4 +162,4 @@ void TinyFile::ejected(uint32_t mediaId) {
 
 FsFile TinyFile::lastFile;
 FsFile TinyFile::lastParent;
-uint32_t TinyFile::lastMediaId;
+uint16_t TinyFile::lastMediaId;

--- a/acsi2stm/TinyFile.h
+++ b/acsi2stm/TinyFile.h
@@ -38,10 +38,10 @@ struct __attribute__((__packed__)) TinyFile {
   }
 
   // Point this TinyFile at a file
-  void set(uint32_t mediaId, FsFile &parent, FsFile &file);
+  void set(uint16_t mediaId, FsFile &parent, FsFile &file);
 
   // Point this TinyFile at the beginning of a folder
-  void set(uint32_t mediaId, FsFile &parent);
+  void set(uint16_t mediaId, FsFile &parent);
 
   // Acquires the file.
   // If mediaId is set, enables the acquire cache, speeding up things a lot.
@@ -62,7 +62,7 @@ struct __attribute__((__packed__)) TinyFile {
   static uint32_t getCluster(FsFile &file);
   static void setCluster(FsFile &file, uint32_t cluster);
 
-  uint32_t mediaId;
+  uint16_t mediaId;
   uint32_t dirCluster;
   uint16_t index;
 
@@ -72,11 +72,11 @@ struct __attribute__((__packed__)) TinyFile {
   static const uint16_t VOLUME = 0xfffd;
 
   static void closeLast();
-  static void ejected(uint32_t mediaId);
+  static void ejected(uint16_t mediaId);
 
   static FsFile lastFile;
   static FsFile lastParent;
-  static uint32_t lastMediaId;
+  static uint16_t lastMediaId;
 };
 
 #endif


### PR DESCRIPTION
Acsi2stm apparently uses a slightly incompatible DTA structure - it expects TOS applications to not write into the documented `char dt_fname[14]` member, since it "hides" the attribute filter value in it's last byte. 

Unfortunately there _are_ corner cases where applications write into, or even completely _clear_ `dt_fname` (case in point e.g. [BUGABOO](https://github.com/sarnau/TurboAss/tree/master/BUGABOO) which clears `dt_fname` completely), expecting this (as per docs) to be a 14 char name buffer and thus effectively overwriting the internal filter attribute state, which in turn breaks trailing fsnext()s. 

To keep Acsi2stms internal data confined to the 21 bytes of reserved space that TOS uses, I hamfistedly changed the mediaId from 32 to 16 bits. This _might_ not be enough  for conflict-free media changes, that's why I'm a bit vary if this is a good approach or not. My low-level SD card experience is practically zero, so take this as "It works here"(tm), but ymmv (and implementing a non-native 24 or 26 bit data type seemed to me like too much complexity spread throughout the code).