### PR TITLE
Implement Fxattr (op $12C) to fix MiNTLib open() on GemDrive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ pcb/MegaSTE Internal/fp-info-cache
 *.gbr
 *.drl
 pcb/MegaSTE Internal/ACSI2STM MegaSTE-backups/*
+.DS_Store
+*.o
+tmp/

--- a/acsi2stm/GemDrive.cpp
+++ b/acsi2stm/GemDrive.cpp
@@ -1295,6 +1295,7 @@ void GemDrive::onGemdos() {
   DECLARE_CALLBACK(Fsfirst);
   DECLARE_CALLBACK(Frename);
   DECLARE_CALLBACK(Fdatime);
+  DECLARE_CALLBACK(Fxattr);
 
   // Just log these callbacks
 #if ACSI_DEBUG
@@ -2026,6 +2027,76 @@ bool GemDrive::onFdatime(const Tos::Fdatime_p &p) {
     dbg(' ');
   }
 
+  return rte(E_OK);
+}
+
+bool GemDrive::onFxattr(const Tos::Fxattr_p &p) {
+  char *path;
+  GemDrive *drive = getDrive(p.fname, &path);
+  if(!drive)
+    return forward();
+  if(!path)
+    return rte(EFILNF);
+
+  GemPath parent = drive->curPath;
+  GemPattern name;
+  if(!parent.openPath(path, name))
+    return rte(EFILNF);
+
+  FsFile file;
+  if(!parent.openFile(name, file))
+    return rte(EFILNF);
+  if(!file)
+    return rte(EFILNF);
+
+  // Build the MiNT XATTR struct (128 bytes, same layout as FreeMiNT kernel).
+  // Fields are Big-Endian; ToWord/ToLong handle that.
+  struct TOS_PACKED {
+    Word  st_mode;
+    Long  st_ino;
+    Word  st_dev;
+    Word  st_rdev;
+    Word  st_nlink;
+    Word  st_uid;
+    Word  st_gid;
+    Long  st_size;
+    Long  st_blksize;
+    Long  st_blocks;
+    Long  st_mtime;   // DOS time+date packed as long (time in high word)
+    Long  st_atime;
+    Long  st_ctime;
+    Word  st_attr;    // DOS attribute byte
+    Word  reserved[3];
+  } xattr;
+  memset(&xattr, 0, sizeof(xattr));
+
+  bool isDir = file.isDir();
+  uint32_t size = isDir ? 0 : (uint32_t)file.fileSize();
+  uint16_t dosTime, dosDate;
+  file.getModifyDateTime(&dosDate, &dosTime);
+  uint32_t packedTime = ((uint32_t)dosTime << 16) | dosDate;
+
+  // st_mode: file type + permissions
+  // Regular file: 0100644 (S_IFREG | rw-r--r--)
+  // Directory:    0040755 (S_IFDIR | rwxr-xr-x)
+  // Read-only DOS attribute maps to no write bits
+  uint16_t mode = isDir ? 0040755 : 0100644;
+  if(!isDir && (file.attrib() & 0x01))  // read-only attribute
+    mode = 0100444;
+
+  xattr.st_mode    = ToWord(mode);
+  xattr.st_ino     = ToLong(0);  // FAT has no persistent inodes
+  xattr.st_dev     = ToWord((uint16_t)(drive->letter() - 'A'));
+  xattr.st_nlink   = ToWord(1);
+  xattr.st_size    = ToLong(size);
+  xattr.st_blksize = ToLong(512);
+  xattr.st_blocks  = ToLong((size + 511) / 512);
+  xattr.st_mtime   = ToLong(packedTime);
+  xattr.st_atime   = ToLong(packedTime);
+  xattr.st_ctime   = ToLong(packedTime);
+  xattr.st_attr    = ToWord((uint16_t)file.attrib());
+
+  sendAt(xattr, p.xattr);
   return rte(E_OK);
 }
 

--- a/acsi2stm/GemDrive.h
+++ b/acsi2stm/GemDrive.h
@@ -199,6 +199,7 @@ struct GemDrive: public Devices, public Tos {
   DECLARE_CALLBACK(Fsnext);
   DECLARE_CALLBACK(Frename);
   DECLARE_CALLBACK(Fdatime);
+  DECLARE_CALLBACK(Fxattr);
 
 #undef DECLARE_CALLBACK
 

--- a/acsi2stm/Tos.h
+++ b/acsi2stm/Tos.h
@@ -418,6 +418,12 @@ struct Tos: public SysHook {
     Word handle;
     Word wflag;
   };
+  // MiNT extended calls
+  DECLARE_FUNCTION(Fxattr, 0x12c, (ToWord flag, const char *fname, void *xattr)) {
+    Word flag;
+    Long fname;
+    Long xattr;
+  };
 #undef DECLARE_FUNCTION
 
   // System call templates


### PR DESCRIPTION
Why is this needed?
---

Programs built with MiNTLib (`m68k-atari-mint` toolchain) fail with `ENOENT` when they try to open files from a GemDrive, even though the same files open fine with `Fopen()`. This includes popular projects like [STDOOM](https://github.com/indyjo/STDOOM) and any other software that uses the standard POSIX I/O layer; including `open()`, `read()`, `stat()`, `access()`, `fstat()`, etc.

The root cause is that MiNTLib's `open()` calls `Fxattr` (GEMDOS op `$12C`) to check if a file exists before issuing `Fopen`. GemDrive had no handler, so it forwarded to TOS, returned `EINVFN` and MiNTLib failed.

What's the solution?
---

With `onFxattr` added to the GemDrive GEMDOS dispatcher, the path resolves using the same `getDrive`/`openPath`/`openFile` chain as `onFopen`, then fills a MiNT `XATTR` struct from the FAT file metadata (mode bits derived from file type and DOS read-only attribute, size, timestamps from `getModifyDateTime`, drive and link count) and returns `E_OK`. This gives MiNTLib's stat probe a valid response, allowing `open()` to proceed normally.

I verified this firmware as working using an [ACSI2STM Mini](https://store.sidecartridge.com/products/acsi2stm-mini-hard-disk-for-atari-st-series) on a real Atari Mega STE: `open()` now returns a valid handle for files on a GemDrive volume, `STDOOM` now loads WAD files, and other MiNTLib apps work as expected.

How can I reproduce this error?
---

1. Use `m68k-atari-mint-gcc -O2 -o GDTEST.TOS gdtest.c` to build this:

   ```c
   // gdtest.c

   #include <fcntl.h>
   #include <stdio.h>
   #include <errno.h>
   #include <mint/osbind.h>

   int main(void) {
       int  h  = open("TEST.DAT", O_RDONLY);          /* MiNTLib POSIX */
       long fh = Fopen("TEST.DAT", 0);                /* raw GEMDOS    */
       printf("open()  -> %d  errno=%d\n", h,  errno);
       printf("Fopen() -> %ld\n", fh);
       if (h != -1) close(h);
       if (fh >= 0) Fclose((short)fh);
       return 0;
   }
   ```

2. Rename any file to `TEST.DAT` put it and `GDTEST.TOS` in the same folder on a GemDrive-mapped SD card.
3. Run `GDTEST.TOS`.

- Expected: both `open()` and `Fopen()` succeed.
- Actual: `open()` returns `-1` with `errno` 33 (ENOENT) or 34 (ENOTDIR); `Fopen()` succeeds.

On a real ACSI/SD partition or Hatari both calls succeed.